### PR TITLE
9 updatechecker seems to check for updates only when the tombstone is absent

### DIFF
--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -137,7 +137,18 @@ class UpdateChecker:
         last_check = self.update_data.get("last_check")
 
         # Check if we need to perform an update check
-        if force or not last_check or (datetime.now() - last_check) > self.check_interval:
+        need_check = force or not last_check
+        if not need_check and isinstance(last_check, datetime):
+            try:
+                need_check = (datetime.now() - last_check) > self.check_interval
+            except (TypeError, ValueError):
+                # If comparison fails, force a check
+                need_check = True
+        elif not need_check:
+            # If last_check exists but isn't a datetime, force a check
+            need_check = True
+
+        if need_check:
             latest_version = self._fetch_latest_version()
 
             # Update the data

--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -189,7 +189,7 @@ class UpdateChecker:
             logger.info(f"Update available for {self.package_name}:")
             logger.info(f"  Current version: {status['current_version']}")
             logger.info(f"  Latest version: {status['latest_version']}")
-            logger.info(f"  Update with: pip install --upgrade {self.package_name}")
+            logger.info(f"  Update with: pip install -U {self.package_name}")
             return True
         elif not quiet:
             logger.info(f"{self.package_name} is up to date ({status['current_version']}).")

--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -37,7 +37,7 @@ class UpdateChecker:
         source (str): The source to check for updates ('pypi' or 'github')
     """
 
-    def __init__(self, package_name, check_interval=timedelta(days=1), source='pypi', repo=None):
+    def __init__(self, package_name, check_interval=timedelta(hours=1), source='pypi', repo=None):
         """
         Initialize the UpdateChecker.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cac-core"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 readme = "README.md"
 license = "MIT"

--- a/tests/test_updatechecker/test_updatechecker.py
+++ b/tests/test_updatechecker/test_updatechecker.py
@@ -241,12 +241,24 @@ class TestUpdateChecker:
 
     def test_check_for_updates_within_interval(self, mock_update_checker):
         """Test update check respects interval."""
-        # Set last check to recent time
-        mock_update_checker.update_data["last_check"] = datetime.now() - timedelta(hours=1)
-        mock_update_checker.update_data["latest_version"] = "1.5.0"
+        real_datetime = datetime.now() - timedelta(hours=1)
+        mock_update_checker.update_data = {
+            "last_check": real_datetime,
+            "latest_version": "1.5.0",
+            "current_version": "1.0.0"
+        }
 
-        with patch.object(mock_update_checker, '_fetch_latest_version') as mock_fetch:
+        mock_update_checker.check_interval = timedelta(hours=2)
+
+        # Patch the get_update_status method to return consistent data
+        with patch.object(mock_update_checker, '_fetch_latest_version') as mock_fetch, \
+            patch.object(mock_update_checker, 'get_update_status', return_value={
+                "latest_version": "1.5.0",
+                "update_available": True
+            }):
+
             status = mock_update_checker.check_for_updates(force=False)
+
             # Should not fetch when within interval
             mock_fetch.assert_not_called()
             assert status["latest_version"] == "1.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "cac-core"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
- **fix the "how to update" message when updates are available**
- **check hourly, not daily**
- **improved update file handling and path**
- **improved need_check logic**
- **improved tests**
- **bump version**
