### PR TITLE
Fix defects from adversarial code review

### DIFF
--- a/cac_core/__init__.py
+++ b/cac_core/__init__.py
@@ -5,13 +5,7 @@ Provides configuration management, credential storage, data modeling,
 output formatting, update checking, and an abstract command framework.
 """
 
-from . import command
-from . import config
-from . import credentialmanager
-from . import logger
-from . import model
-from . import output
-from . import updatechecker
+from . import command, config, credentialmanager, logger, model, output, updatechecker
 
 __all__ = [
     "command",

--- a/cac_core/cli.py
+++ b/cac_core/cli.py
@@ -10,6 +10,8 @@ import argparse
 import logging
 import sys
 
+from cac_core.command import CommandError
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,6 +66,10 @@ class CLI:
 
         try:
             module.execute(self.opts)
+        except CommandError as e:
+            # Honor the exit code the command requested instead of forcing 1.
+            logger.error("Error executing command '%s': %s", command, e.message)
+            sys.exit(e.exit_code)
         except Exception:
             logger.exception("Error executing command '%s'", command)
             sys.exit(1)

--- a/cac_core/command.py
+++ b/cac_core/command.py
@@ -122,6 +122,10 @@ class Command(metaclass=abc.ABCMeta):
         Returns:
             tuple: (success, result_or_error)
         """
+        # Loggers are process-wide singletons keyed by class name, so raising
+        # the level for a verbose run would leak DEBUG into later non-verbose
+        # runs. Remember the prior level and restore it when we're done.
+        previous_level = self.log.level
         try:
             # Set log level if verbose flag is present
             if args.get("verbose", False):
@@ -142,3 +146,7 @@ class Command(metaclass=abc.ABCMeta):
             # Catch unexpected exceptions
             self.log.exception(f"Unexpected error executing {self.__class__.__name__}")
             return False, CommandError(f"Unexpected error: {str(e)}")
+
+        finally:
+            if args.get("verbose", False):
+                self.log.setLevel(previous_level)

--- a/cac_core/command.py
+++ b/cac_core/command.py
@@ -37,6 +37,8 @@ class Command(metaclass=abc.ABCMeta):
         Initialize the command.
         """
         self.log = logging.getLogger(self.__class__.__name__)
+        if log_level is not None:
+            self.log.setLevel(log_level)
 
     @staticmethod
     def define_common_arguments(parser) -> None:
@@ -131,8 +133,11 @@ class Command(metaclass=abc.ABCMeta):
             if args.get("verbose", False):
                 self.log.setLevel(logging.DEBUG)
 
-            # Validate arguments first
-            self.validate_args(args)
+            # Validate arguments first. Subclasses may either raise CommandError
+            # or signal invalid input by returning False (per the documented
+            # return contract); honor both.
+            if self.validate_args(args) is False:
+                raise CommandError("Argument validation failed")
 
             # Execute the command
             result = self.execute(args)

--- a/cac_core/config.py
+++ b/cac_core/config.py
@@ -221,7 +221,16 @@ class Config:
 
         # Navigate to the nested location, creating dictionaries as needed
         for part in parts[:-1]:
-            if part not in current or not isinstance(current[part], dict):
+            if part not in current:
+                current[part] = {}
+            elif not isinstance(current[part], dict):
+                # An existing non-dict value blocks the nested path; warn before
+                # replacing it so silently destroying data is at least visible.
+                logger.warning(
+                    "Overwriting non-dict value at %r while setting %r",
+                    part,
+                    key_path,
+                )
                 current[part] = {}
             current = current[part]
 
@@ -377,9 +386,15 @@ class Config:
             # Ensure the directory exists
             os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
 
+            # config_file_path is a runtime-derived convenience key, not user
+            # data; don't persist it (or a stale absolute path) into the YAML.
+            save_data = {
+                k: v for k, v in self.config.items() if k != "config_file_path"
+            }
+
             # Write the config to file
             with open(self.config_file, "w", encoding="utf-8") as f:
-                yaml.dump(self.config, f)
+                yaml.dump(save_data, f)
 
             return True
         except (IOError, OSError) as e:

--- a/cac_core/config.py
+++ b/cac_core/config.py
@@ -106,13 +106,40 @@ class Config:
                 continue
 
             # Remove prefix and convert to lowercase
-            config_key = env_key[len(f"{self.env_prefix}_") :].lower()
+            raw_key = env_key[len(f"{self.env_prefix}_") :].lower()
 
-            # Replace underscores with dots for nested keys
-            config_key = config_key.replace("_", ".")
+            # Prefer an existing top-level key that matches literally (so keys
+            # that legitimately contain underscores, e.g. "log_level", can be
+            # overridden); otherwise map underscores to dots for nested keys.
+            if raw_key in self.config:
+                config_key = raw_key
+            else:
+                config_key = raw_key.replace("_", ".")
+
+            # Coerce the string env value to match the existing value's type,
+            # so numeric/boolean config values aren't silently turned to strings.
+            value = self._coerce_env_value(config_key, env_value)
 
             # Set the value in our config
-            self.set(config_key, env_value)
+            self.set(config_key, value)
+
+    def _coerce_env_value(self, config_key, env_value):
+        """
+        Coerce a string environment value to the type of the existing config
+        value at ``config_key`` (bool/int/float). Falls back to the raw string
+        if there is no existing typed value or the conversion fails.
+        """
+        current = self.get(config_key)
+        try:
+            if isinstance(current, bool):
+                return env_value.strip().lower() in ("1", "true", "yes", "on")
+            if isinstance(current, int):
+                return int(env_value)
+            if isinstance(current, float):
+                return float(env_value)
+        except (ValueError, AttributeError):
+            return env_value
+        return env_value
 
     def _load_config(self):
         """
@@ -310,6 +337,11 @@ class Config:
             # print(f"Module {module_name} not found in sys.modules.")
             return default_config
 
+        # Namespace/frozen packages may have __file__ = None; there is no
+        # on-disk config directory to derive, so return empty defaults.
+        if not module_path:
+            return default_config
+
         module_dir = os.path.dirname(module_path)
         default_config_dir = os.path.join(module_dir, "config")
         default_config_file = os.path.join(default_config_dir, f"{module_name}.yaml")
@@ -387,14 +419,15 @@ class Config:
         """
         try:
             import jsonschema  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            logger.warning("jsonschema package not installed, skipping validation")
+            return True, ["jsonschema not installed"]
 
+        try:
             jsonschema.validate(self.config, schema)
             return True, []
         except jsonschema.exceptions.ValidationError as e:
             return False, [str(e)]
-        except ImportError:
-            logger.warning("jsonschema package not installed, skipping validation")
-            return True, ["jsonschema not installed"]
 
     def __enter__(self):
         """Support for with statement: with Config() as config:"""

--- a/cac_core/config.py
+++ b/cac_core/config.py
@@ -75,11 +75,13 @@ class Config:
 
         # Add each config key-value pair as an object attribute
         # Done after env var loading so attributes reflect overrides.
-        # Skip keys that would shadow existing methods/attributes (e.g. get,
-        # set, save, load) or private attributes; those remain accessible via
-        # get()/dict-style access instead of clobbering the class API.
+        # Skip keys that would shadow existing methods or instance attributes
+        # (e.g. get/set/save/load, or config/config_file/env_prefix) or private
+        # attributes; those remain accessible via get()/dict-style access
+        # instead of clobbering the class API or internal state. hasattr(self,
+        # ...) covers both class members and already-set instance attributes.
         for key, value in self.config.items():
-            if key.startswith("_") or hasattr(type(self), key):
+            if key.startswith("_") or hasattr(self, key):
                 logger.warning(
                     "Config key %r collides with a reserved attribute; "
                     "not exposing it as an attribute (use get(%r) instead).",

--- a/cac_core/config.py
+++ b/cac_core/config.py
@@ -74,8 +74,19 @@ class Config:
         self._load_env_vars()
 
         # Add each config key-value pair as an object attribute
-        # Done after env var loading so attributes reflect overrides
+        # Done after env var loading so attributes reflect overrides.
+        # Skip keys that would shadow existing methods/attributes (e.g. get,
+        # set, save, load) or private attributes; those remain accessible via
+        # get()/dict-style access instead of clobbering the class API.
         for key, value in self.config.items():
+            if key.startswith("_") or hasattr(type(self), key):
+                logger.warning(
+                    "Config key %r collides with a reserved attribute; "
+                    "not exposing it as an attribute (use get(%r) instead).",
+                    key,
+                    key,
+                )
+                continue
             setattr(self, key, value)
 
     def _load_env_vars(self):
@@ -244,11 +255,42 @@ class Config:
             with open(self.config_file, "r", encoding="utf-8") as f:
                 user_config = yaml.safe_load(f)
                 if user_config:
-                    config.update(user_config)
+                    # Deep-merge so a user override of one nested key does not
+                    # drop sibling default keys in the same subtree.
+                    config = self._deep_merge(config, user_config)
         except Exception as e:
             logger.error("Error reading user config file %s: %s", self.config_file, e)
 
         return config
+
+    @staticmethod
+    def _deep_merge(base, override):
+        """
+        Recursively merge ``override`` into ``base`` and return the result.
+
+        Nested dictionaries are merged key-by-key so that overriding a single
+        nested value preserves the other keys defined in the base dict. Any
+        non-dict value (or a dict overriding a non-dict, and vice versa)
+        replaces the base value outright.
+
+        Args:
+            base (dict): The base dictionary (e.g. default config).
+            override (dict): The dictionary whose values take precedence.
+
+        Returns:
+            dict: A new dictionary containing the merged result.
+        """
+        merged = dict(base)
+        for key, value in override.items():
+            if (
+                key in merged
+                and isinstance(merged[key], dict)
+                and isinstance(value, dict)
+            ):
+                merged[key] = Config._deep_merge(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
 
     def _load_default_config(self, module_name):
         """

--- a/cac_core/credentialmanager.py
+++ b/cac_core/credentialmanager.py
@@ -104,8 +104,14 @@ class CredentialManager:
         # Store username for reference
         self.username = username
 
-        # Try to get credential from keychain
-        credential_string = keyring.get_password(self.module_name, username)
+        # Try to get credential from keychain. Guard against backend errors
+        # (e.g. locked/unavailable keyring) so we degrade to a prompt rather
+        # than crashing the caller, matching set/delete_credential behavior.
+        try:
+            credential_string = keyring.get_password(self.module_name, username)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error("Failed to read credential for %s: %s", username, e)
+            credential_string = None
 
         # If not found and prompting is enabled
         if not credential_string and prompt:

--- a/cac_core/logger.py
+++ b/cac_core/logger.py
@@ -59,13 +59,15 @@ def new(name, level=logging.INFO, format_string=None) -> logging.Logger:
         sh = logging.StreamHandler()
         sh.setFormatter(formatter)
         logger.addHandler(sh)
-        # This logger has its own handler; don't also bubble records to
-        # ancestor handlers (e.g. root) and emit every line twice.
-        logger.propagate = False
     else:
         # Reconfigure existing handlers so a later new(name, level=DEBUG) call
         # (e.g. after parsing --verbose) actually updates the output format.
         for handler in logger.handlers:
             handler.setFormatter(formatter)
+
+    # This logger has its own handler; don't also bubble records to ancestor
+    # handlers (e.g. root) and emit every line twice. Set unconditionally so
+    # propagation is disabled even when handlers were configured elsewhere.
+    logger.propagate = False
 
     return logger

--- a/cac_core/logger.py
+++ b/cac_core/logger.py
@@ -52,5 +52,8 @@ def new(name, level=logging.INFO, format_string=None) -> logging.Logger:
         formatter = logging.Formatter(format_string)
         sh.setFormatter(formatter)
         logger.addHandler(sh)
+        # This logger has its own handler; don't also bubble records to
+        # ancestor handlers (e.g. root) and emit every line twice.
+        logger.propagate = False
 
     return logger

--- a/cac_core/logger.py
+++ b/cac_core/logger.py
@@ -34,26 +34,38 @@ def new(name, level=logging.INFO, format_string=None) -> logging.Logger:
     """
     logger = logging.getLogger(name)
 
+    # Normalize string level names (e.g. "DEBUG") to their numeric value so
+    # level comparisons below work regardless of how the caller passed it.
+    if isinstance(level, str):
+        level = logging.getLevelName(level.upper())
+        if not isinstance(level, int):
+            level = logging.INFO
+
     # Always update the level so callers can reconfigure after initial creation
     # (e.g., switching to DEBUG after parsing --verbose)
     logger.setLevel(level)
 
-    # Only add handler if the logger doesn't already have one
+    # Choose the format: verbose (DEBUG or lower) gets the detailed layout.
+    # Use <= so sub-DEBUG numeric levels also get the verbose format.
+    if not format_string:
+        if level <= logging.DEBUG:
+            format_string = "%(asctime)s [%(levelname)s] (%(processName)s %(threadName)s) %(module)s:%(lineno)d: %(message)s"
+        else:
+            format_string = "%(asctime)s [%(levelname)s] %(message)s"
+
+    formatter = logging.Formatter(format_string)
+
     if not logger.handlers:
         sh = logging.StreamHandler()
-
-        # Use provided format or default
-        if not format_string:
-            if level == logging.DEBUG:
-                format_string = "%(asctime)s [%(levelname)s] (%(processName)s %(threadName)s) %(module)s:%(lineno)d: %(message)s"
-            else:
-                format_string = "%(asctime)s [%(levelname)s] %(message)s"
-
-        formatter = logging.Formatter(format_string)
         sh.setFormatter(formatter)
         logger.addHandler(sh)
         # This logger has its own handler; don't also bubble records to
         # ancestor handlers (e.g. root) and emit every line twice.
         logger.propagate = False
+    else:
+        # Reconfigure existing handlers so a later new(name, level=DEBUG) call
+        # (e.g. after parsing --verbose) actually updates the output format.
+        for handler in logger.handlers:
+            handler.setFormatter(formatter)
 
     return logger

--- a/cac_core/model.py
+++ b/cac_core/model.py
@@ -85,10 +85,11 @@ class Model:
         )
 
     def __iter__(self):
-        # Iterate in insertion order so key/value pairing stays consistent
-        # with keys()/to_dict(); field_names is an unordered set.
+        # Mapping protocol: iterating a Model yields its keys (in insertion
+        # order), consistent with dict and with keys(). Use items() for
+        # key/value pairs and values() for values.
         for key in self._key_order:
-            yield key, self.data.get(key)
+            yield key
 
     def items(self) -> List[Tuple[str, Any]]:
         """Returns key-value pairs as a list of tuples"""

--- a/cac_core/model.py
+++ b/cac_core/model.py
@@ -125,7 +125,8 @@ class Model:
         Returns:
             list: A list of all keys in the model in insertion order.
         """
-        return self._key_order
+        # Return a copy so callers cannot mutate the model's private ordering.
+        return list(self._key_order)
 
     def to_dict(self):
         """
@@ -206,7 +207,16 @@ class Model:
             self.field_names.add(key)
             self._key_order.append(key)
             self.add_key(key, value)
-        self.data[key] = value
+        # Wrap nested dicts/lists in Model like __init__ does, so nested
+        # attribute access works regardless of how the value was set.
+        if isinstance(value, list):
+            self.data[key] = [
+                Model(val) if isinstance(val, dict) else val for val in value
+            ]
+        elif isinstance(value, dict):
+            self.data[key] = Model(value)
+        else:
+            self.data[key] = value
 
     def __contains__(self, key):
         """Support for 'in' operator: key in model"""
@@ -230,6 +240,8 @@ class Model:
         new_model.data = copy.copy(self.data)
         new_model.field_names = copy.copy(self.field_names)
         new_model._key_order = copy.copy(self._key_order)
+        new_model._formatters = copy.copy(self._formatters)
+        new_model._remove_keys = copy.copy(self._remove_keys)
         return new_model
 
     def __deepcopy__(self, memo):
@@ -239,6 +251,8 @@ class Model:
         new_model.data = copy.deepcopy(self.data, memo)
         new_model.field_names = copy.deepcopy(self.field_names, memo)
         new_model._key_order = copy.deepcopy(self._key_order, memo)
+        new_model._formatters = copy.deepcopy(self._formatters, memo)
+        new_model._remove_keys = copy.deepcopy(self._remove_keys, memo)
         return new_model
 
     def validate(self) -> List[str]:

--- a/cac_core/model.py
+++ b/cac_core/model.py
@@ -11,8 +11,8 @@ The Model class automatically converts nested dictionaries into Model instances
 and supports serialization to dictionaries and JSON for data exchange.
 """
 
-import json
 import copy
+import json
 from typing import Any, Dict, List, Optional, Set, Tuple  # , Union
 
 

--- a/cac_core/model.py
+++ b/cac_core/model.py
@@ -85,13 +85,15 @@ class Model:
         )
 
     def __iter__(self):
-        for key in self.field_names:
-            yield key, getattr(self, key)
+        # Iterate in insertion order so key/value pairing stays consistent
+        # with keys()/to_dict(); field_names is an unordered set.
+        for key in self._key_order:
+            yield key, self.data.get(key)
 
     def items(self) -> List[Tuple[str, Any]]:
         """Returns key-value pairs as a list of tuples"""
         result = []
-        for key in self.field_names:
+        for key in self._key_order:
             # Get the actual value from data dictionary instead of using getattr
             value = self.data.get(key)
             result.append((key, value))
@@ -99,7 +101,7 @@ class Model:
 
     def values(self) -> List[Any]:
         """Returns values as a list"""
-        return [self.data.get(key) for key in self.field_names]
+        return [self.data.get(key) for key in self._key_order]
 
     def __str__(self):
         return f"#<{self.__class__.__name__} {self.current_state()}>"
@@ -166,7 +168,7 @@ class Model:
         Returns:
             str: A string representation of the model's current state.
         """
-        return " ".join(f"{key}={getattr(self, key)}" for key in self.field_names)
+        return " ".join(f"{key}={self.data.get(key)}" for key in self._key_order)
 
     def _process_results(self, value):
         if isinstance(value, Model):

--- a/cac_core/output.py
+++ b/cac_core/output.py
@@ -10,6 +10,7 @@ tables and JSON, and adapts to different terminal environments.
 
 import json
 import logging
+
 import tabulate
 
 

--- a/cac_core/output.py
+++ b/cac_core/output.py
@@ -44,7 +44,7 @@ class Output:
 
         For table output:
         - Complex nested structures are flattened for tabular display
-        - Headers are derived from the first model's keys
+        - Headers are the union of all models' keys (first-seen order)
         - Displays a row count after the table
 
         Args:
@@ -99,8 +99,8 @@ class Output:
             if not data_models:
                 self.logger.info("No results were found")
                 return
-            self.__resolve_models(data_models)
-            self.__output_to_table(data_models, table_options)
+            resolved = self.__resolve_models(data_models)
+            self.__output_to_table(resolved, table_options)
 
     def _get_param(self, key, default=None):
         """
@@ -130,12 +130,17 @@ class Output:
     def __create_logger(self):
         logger = logging.getLogger("OutputTable")
         logger.setLevel(logging.INFO)
-        sh = logging.StreamHandler()
-        formatter = logging.Formatter(
-            "%(asctime)s [%(levelname)s] (%(processName)s %(threadName)s) %(module)s:%(lineno)d: %(message)s"
-        )
-        sh.setFormatter(formatter)
-        logger.addHandler(sh)
+        # The named logger is a process-wide singleton; only attach a handler
+        # once so repeated Output() instances don't produce duplicate output.
+        if not logger.handlers:
+            sh = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s [%(levelname)s] (%(processName)s %(threadName)s) %(module)s:%(lineno)d: %(message)s"
+            )
+            sh.setFormatter(formatter)
+            logger.addHandler(sh)
+            # Don't also bubble to ancestor handlers (e.g. root) and double-log.
+            logger.propagate = False
         return logger
 
     def __models_to_dict(self, data_models):
@@ -158,8 +163,13 @@ class Output:
         formatters = table_options.get("formatters") or {}
         widths = table_options.get("width") or {}
 
-        # Get ordered column keys from first model, dropping excluded columns
-        columns = [key for key in data_models[0].keys() if key not in exclude]
+        # Union of column keys across all rows (first-seen order), so columns
+        # present only in later rows are not silently dropped.
+        columns = []
+        for model in data_models:
+            for key in model.keys():
+                if key not in exclude and key not in columns:
+                    columns.append(key)
 
         # Display headers honor any custom header mappings
         headers = [header_map.get(key, key) for key in columns]
@@ -195,17 +205,31 @@ class Output:
         print(f"{row_count} {'row' if row_count == 1 else 'rows'}")
 
     def __resolve_models(self, data_models):
+        # Build flattened plain-dict rows WITHOUT mutating the caller's models;
+        # rendering must not corrupt the caller's data as a side effect.
+        resolved = []
         for model in data_models:
+            row = {}
             for k, v in model.items():
-                if isinstance(v, dict):
-                    model[k] = json.dumps(v)
-                elif isinstance(v, list):
-                    model[k] = ", ".join(
+                if isinstance(v, list):
+                    row[k] = ", ".join(
                         [
-                            json.dumps(x.to_dict()) if hasattr(x, "to_dict") else str(x)
+                            (
+                                json.dumps(x.to_dict())
+                                if hasattr(x, "to_dict")
+                                else (json.dumps(x) if isinstance(x, dict) else str(x))
+                            )
                             for x in v
                         ]
                     )
+                elif hasattr(v, "to_dict"):
+                    row[k] = json.dumps(v.to_dict())
+                elif isinstance(v, dict):
+                    row[k] = json.dumps(v)
+                else:
+                    row[k] = v
+            resolved.append(row)
+        return resolved
 
 
 # Example usage

--- a/cac_core/output.py
+++ b/cac_core/output.py
@@ -148,18 +148,38 @@ class Output:
     def __output_to_json(self, data_models):
         print(json.dumps(self.__models_to_dict(data_models)))
 
-    def __output_to_table(self, data_models, _table_options):
+    def __output_to_table(self, data_models, table_options=None):
         if not data_models:
             return
 
-        # Get ordered headers from first model
-        headers = list(data_models[0].keys())
+        table_options = table_options or {}
+        exclude = set(table_options.get("exclude") or [])
+        header_map = table_options.get("headers") or {}
+        formatters = table_options.get("formatters") or {}
+        widths = table_options.get("width") or {}
+
+        # Get ordered column keys from first model, dropping excluded columns
+        columns = [key for key in data_models[0].keys() if key not in exclude]
+
+        # Display headers honor any custom header mappings
+        headers = [header_map.get(key, key) for key in columns]
 
         table_data = []
         for model in data_models:
-            # For each model, extract values in the same order as headers
-            row = [model.get(key) for key in headers]
+            row = []
+            for key in columns:
+                value = model.get(key)
+                if key in formatters:
+                    value = formatters[key](value)
+                row.append(value)
             table_data.append(row)
+
+        # Per-column fixed widths, aligned with the column order (None = auto)
+        maxcolwidths = (
+            [widths.get(key) for key in columns]
+            if any(key in widths for key in columns)
+            else None
+        )
 
         print(
             tabulate.tabulate(
@@ -168,6 +188,7 @@ class Output:
                 tablefmt="pretty",
                 stralign="left",
                 numalign="right",
+                maxcolwidths=maxcolwidths,
             )
         )
         row_count = len(table_data)
@@ -180,7 +201,10 @@ class Output:
                     model[k] = json.dumps(v)
                 elif isinstance(v, list):
                     model[k] = ", ".join(
-                        [json.dumps(x) if hasattr(x, "to_dict") else str(x) for x in v]
+                        [
+                            json.dumps(x.to_dict()) if hasattr(x, "to_dict") else str(x)
+                            for x in v
+                        ]
                     )
 
 

--- a/cac_core/output.py
+++ b/cac_core/output.py
@@ -140,8 +140,10 @@ class Output:
             )
             sh.setFormatter(formatter)
             logger.addHandler(sh)
-            # Don't also bubble to ancestor handlers (e.g. root) and double-log.
-            logger.propagate = False
+        # Don't also bubble to ancestor handlers (e.g. root) and double-log.
+        # Set unconditionally so propagation is disabled even when a handler
+        # was configured elsewhere.
+        logger.propagate = False
         return logger
 
     def __models_to_dict(self, data_models):
@@ -165,11 +167,14 @@ class Output:
         widths = table_options.get("width") or {}
 
         # Union of column keys across all rows (first-seen order), so columns
-        # present only in later rows are not silently dropped.
+        # present only in later rows are not silently dropped. A seen-set keeps
+        # membership checks O(1) rather than O(n) against the growing list.
         columns = []
+        seen = set()
         for model in data_models:
             for key in model.keys():
-                if key not in exclude and key not in columns:
+                if key not in exclude and key not in seen:
+                    seen.add(key)
                     columns.append(key)
 
         # Display headers honor any custom header mappings

--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -6,16 +6,17 @@ This module allows any package to check for updates and notify the user when new
 It supports checking both cac-core itself and any dependent packages.
 """
 
-import os
-import sys
+import importlib.metadata
 import json
 import logging
-import importlib.metadata
-import requests
+import os
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from packaging.version import parse as parse_version
+
+import requests
 from packaging.version import InvalidVersion
+from packaging.version import parse as parse_version
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -20,9 +20,13 @@ from packaging.version import InvalidVersion
 # Set up logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-logger.addHandler(handler)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.addHandler(handler)
+    # Don't also bubble to ancestor handlers (e.g. a root handler configured
+    # by the host application) and emit every line twice.
+    logger.propagate = False
 
 
 class UpdateChecker:
@@ -89,9 +93,20 @@ class UpdateChecker:
             import tempfile
 
             self.data_dir = Path(tempfile.gettempdir()) / package_name
-            self.data_dir.mkdir(exist_ok=True, parents=True)
+            try:
+                self.data_dir.mkdir(exist_ok=True, parents=True)
+            except (PermissionError, OSError) as tmp_err:
+                # Even the temp dir is unwritable; degrade to in-memory-only
+                # rather than crashing the caller's constructor.
+                logger.warning(
+                    f"Could not create fallback data directory {self.data_dir}: {tmp_err}"
+                )
+                self.data_dir = None
 
-        self.data_file = self.data_dir / "update.json"
+        self.data_file = (self.data_dir / "update.json") if self.data_dir else None
+
+        # Whether the most recent fetch succeeded; gates last_check advancement.
+        self._last_fetch_ok = True
 
         # Load existing data
         self.update_data = self._load_update_data()
@@ -99,12 +114,22 @@ class UpdateChecker:
     def _load_update_data(self):
         """Load update data from the local file."""
         try:
-            if self.data_file.exists():
+            if self.data_file and self.data_file.exists():
                 with open(self.data_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                    # Convert string to datetime
-                    if data.get("last_check"):
-                        data["last_check"] = datetime.fromisoformat(data["last_check"])
+                    # A valid-JSON-but-non-object file (null, list, scalar) is
+                    # not usable update data; fall back to defaults.
+                    if not isinstance(data, dict):
+                        raise ValueError("update data is not a JSON object")
+                    # Convert string to datetime; tolerate a malformed or
+                    # non-string last_check instead of crashing.
+                    last_check = data.get("last_check")
+                    if last_check:
+                        try:
+                            data["last_check"] = datetime.fromisoformat(last_check)
+                        except (TypeError, ValueError):
+                            logger.debug("Invalid last_check value; ignoring it")
+                            data["last_check"] = None
                     return data
         except (json.JSONDecodeError, ValueError) as e:
             logger.debug(f"Error loading update data: {e}")
@@ -120,6 +145,9 @@ class UpdateChecker:
 
     def _save_update_data(self):
         """Save update data to the local file."""
+        if not self.data_file:
+            # No writable location available; nothing to persist.
+            return
         try:
             # Convert datetime to string for JSON serialization
             save_data = self.update_data.copy()
@@ -159,9 +187,13 @@ class UpdateChecker:
             latest_version = self._fetch_latest_version()
 
             # Update the data
-            self.update_data["last_check"] = datetime.now()
             self.update_data["latest_version"] = latest_version
             self.update_data["current_version"] = self.current_version
+            # Only advance last_check on a successful fetch, so a transient
+            # network/parse failure doesn't suppress retries for the whole
+            # check interval.
+            if self._last_fetch_ok:
+                self.update_data["last_check"] = datetime.now()
 
             # Save the updated data
             self._save_update_data()
@@ -171,6 +203,7 @@ class UpdateChecker:
 
     def _fetch_latest_version(self):
         """Fetch the latest version from the configured source."""
+        self._last_fetch_ok = True
         try:
             response = requests.get(self.update_url, timeout=5)
             response.raise_for_status()
@@ -184,9 +217,11 @@ class UpdateChecker:
 
         except requests.RequestException as e:
             logger.debug(f"Error checking for updates: {e}")
+            self._last_fetch_ok = False
             return self.update_data.get("latest_version") or self.current_version
         except (json.JSONDecodeError, KeyError) as e:
             logger.debug(f"Error parsing update response: {e}")
+            self._last_fetch_ok = False
             return self.update_data.get("latest_version") or self.current_version
 
     def get_update_status(self):

--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -25,9 +25,10 @@ if not logger.handlers:
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
     logger.addHandler(handler)
-    # Don't also bubble to ancestor handlers (e.g. a root handler configured
-    # by the host application) and emit every line twice.
-    logger.propagate = False
+# Don't also bubble to ancestor handlers (e.g. a root handler configured by the
+# host application) and emit every line twice. Set unconditionally so
+# propagation is disabled even when a handler was configured elsewhere.
+logger.propagate = False
 
 
 class UpdateChecker:

--- a/cac_core/updatechecker.py
+++ b/cac_core/updatechecker.py
@@ -15,6 +15,7 @@ import requests
 from datetime import datetime, timedelta
 from pathlib import Path
 from packaging.version import parse as parse_version
+from packaging.version import InvalidVersion
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -195,14 +196,23 @@ class UpdateChecker:
         Returns:
             dict: Update status containing current_version, latest_version, and update_available.
         """
-        current = parse_version(self.current_version)
-        latest = parse_version(self.update_data.get("latest_version") or "0.0.0")
+        latest_version = self.update_data.get("latest_version") or "0.0.0"
+        # A remote (e.g. GitHub tag) or hand-edited version may not be PEP 440
+        # compliant; treat an unparseable version as "no update available"
+        # rather than crashing the caller's CLI.
+        try:
+            current = parse_version(self.current_version)
+            latest = parse_version(latest_version)
+            update_available = latest > current
+        except InvalidVersion as e:
+            logger.debug(f"Could not compare versions: {e}")
+            update_available = False
 
         return {
             "package_name": self.package_name,
             "current_version": self.current_version,
             "latest_version": self.update_data.get("latest_version"),
-            "update_available": latest > current,
+            "update_available": update_available,
             "last_checked": self.update_data.get("last_check"),
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,6 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
+
+[tool.isort]
+profile = "black"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ Example:
 
 import os
 import tempfile
+
 import pytest
 import yaml
 

--- a/tests/test_command/test_command.py
+++ b/tests/test_command/test_command.py
@@ -157,15 +157,24 @@ class TestCommand:
         assert "Unexpected error" in result.message
 
     def test_verbose_mode_changes_log_level(self, simple_command):
-        """Test that verbose flag changes log level."""
+        """Verbose sets DEBUG during execution and restores the level after."""
         original_level = simple_command.log.level
 
-        simple_command.safe_execute({"verbose": True})
+        # Capture the level while execute() is running.
+        observed = {}
 
-        assert simple_command.log.level == logging.DEBUG
+        def record_level(_args):
+            observed["level"] = simple_command.log.level
+            return None
 
-        # Reset log level
-        simple_command.log.setLevel(original_level)
+        with patch.object(simple_command, "execute", side_effect=record_level):
+            simple_command.safe_execute({"verbose": True})
+
+        # DEBUG was active during the command...
+        assert observed["level"] == logging.DEBUG
+        # ...and the shared logger's level is restored afterward so it does not
+        # leak DEBUG into subsequent non-verbose runs.
+        assert simple_command.log.level == original_level
 
     def test_validate_args(self, simple_command):
         """Test argument validation."""

--- a/tests/test_command/test_command.py
+++ b/tests/test_command/test_command.py
@@ -8,6 +8,7 @@ parsing, execution flow, error handling, and subclass behavior.
 import argparse
 import logging
 from unittest.mock import patch  # , MagicMock
+
 import pytest
 
 # import cac_core as cac
@@ -91,7 +92,9 @@ class TestCommand:
         """Test that define_arguments adds common arguments."""
         parser = simple_command.define_arguments(mock_parser)
 
-        actions = {action.dest: action for action in parser._actions}  # pylint: disable=protected-access
+        actions = {
+            action.dest: action for action in parser._actions
+        }  # pylint: disable=protected-access
         assert "output" in actions
         assert "test" in actions  # Custom argument
 
@@ -103,7 +106,9 @@ class TestCommand:
         Command.define_common_arguments(mock_parser)
 
         # Check that there's only one output argument and it hasn't been overridden
-        output_actions = [a for a in mock_parser._actions if a.dest == "output"]  # pylint: disable=protected-access
+        output_actions = [
+            a for a in mock_parser._actions if a.dest == "output"
+        ]  # pylint: disable=protected-access
         assert len(output_actions) == 1
         assert output_actions[0].choices == [
             "csv",

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+
 import pytest
 import yaml
 
@@ -266,9 +267,9 @@ class TestConfig:
 
         for module_name, expected_prefix in test_cases:
             config = Config(module_name)
-            assert config.env_prefix == expected_prefix, (
-                f"Module name '{module_name}' should convert to env prefix '{expected_prefix}'"
-            )
+            assert (
+                config.env_prefix == expected_prefix
+            ), f"Module name '{module_name}' should convert to env prefix '{expected_prefix}'"
 
     def test_load_nonexistent_file(self):
         """Test loading a nonexistent file with _load_config method."""
@@ -343,9 +344,9 @@ class TestConfig:
             # Verify file contains a valid YAML empty dict
             with open(config_path, "r", encoding="utf-8") as f:
                 file_content = yaml.safe_load(f)
-                assert file_content is None or file_content == {}, (
-                    "Empty config should save as empty dict"
-                )
+                assert (
+                    file_content is None or file_content == {}
+                ), "Empty config should save as empty dict"
 
             # Load the empty config into a new object
             config2 = Config("empty-test")
@@ -423,9 +424,9 @@ class TestConfig:
             # Verify the file has content
             with open(temp_file, "r", encoding="utf-8") as f:
                 saved_content = yaml.safe_load(f)
-                assert saved_content and len(saved_content) > 0, (
-                    "File should have initial content"
-                )
+                assert (
+                    saved_content and len(saved_content) > 0
+                ), "File should have initial content"
 
             # Now create a new config object pointing to the same file
             config = Config("test-app")
@@ -443,9 +444,9 @@ class TestConfig:
             config2 = Config("test-app")
             config2.config_file = temp_file
             config2.config = config2._load_config()
-            assert len(config2.config) > 0, (
-                "File should not be cleared until save is called"
-            )
+            assert (
+                len(config2.config) > 0
+            ), "File should not be cleared until save is called"
 
             # Now save the empty config and verify it persists
             config.save()

--- a/tests/test_model/test_model.py
+++ b/tests/test_model/test_model.py
@@ -55,6 +55,21 @@ class TestModel:
         assert model.get("name") == "Test Project"
         assert model.get("nonexistent", "default") == "default"
 
+    def test_model_iteration_yields_keys(self):
+        """Iterating a Model yields keys (mapping protocol), like a dict."""
+        model = cac.model.Model({"a": 1, "b": 2, "c": 3})
+
+        # __iter__ yields keys, in insertion order, matching keys().
+        assert list(model) == ["a", "b", "c"]
+        assert list(model) == model.keys()
+
+        # Standard mapping operations behave consistently.
+        assert set(model) == {"a", "b", "c"}
+        assert dict(model) == {"a": 1, "b": 2, "c": 3}
+
+        # The documented way to iterate pairs is items().
+        assert dict(model.items()) == {"a": 1, "b": 2, "c": 3}
+
     def test_model_to_dict(self, sample_data):
         """Test conversion to dictionary."""
         model = cac.model.Model(sample_data)

--- a/tests/test_updatechecker/test_updatechecker.py
+++ b/tests/test_updatechecker/test_updatechecker.py
@@ -6,12 +6,12 @@ These tests verify that the UpdateChecker correctly checks for package updates,
 handles various error conditions gracefully, and properly notifies users.
 """
 
+import importlib.metadata
 import json
 import tempfile
 from datetime import datetime, timedelta
-import importlib.metadata
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests

--- a/tests/test_updatechecker/test_updatechecker.py
+++ b/tests/test_updatechecker/test_updatechecker.py
@@ -302,10 +302,13 @@ class TestUpdateChecker:
         status = mock_update_checker.get_update_status()
         assert status["update_available"] is False
 
-        # Test with invalid version
+        # Test with invalid (non-PEP 440) version: should degrade gracefully
+        # to "no update available" rather than raising InvalidVersion.
+        mock_update_checker.current_version = "1.0.0"
         mock_update_checker.update_data["latest_version"] = "invalid"
-        with pytest.raises(Exception):
-            mock_update_checker.get_update_status()
+        status = mock_update_checker.get_update_status()
+        assert status["update_available"] is False
+        assert status["latest_version"] == "invalid"
 
     def test_notify_if_update_available(self, mock_update_checker):
         """Test update notification using direct logger mocking."""


### PR DESCRIPTION
## Summary

Addresses defects surfaced by an adversarial code review of the full source (each finding was verified by a skeptic panel before inclusion). Grouped by severity across four commits, plus a formatting pass.

**All 102 tests + doctests pass; `black` and `isort` clean.**

## ⚠️ Breaking change

`Model.__iter__` now yields **keys** (mapping protocol) instead of `(key, value)` tuples, so it agrees with `dict(model)`, `keys()`, and standard dict-like behavior. Downstream code doing `for k, v in model:` must switch to `for k, v in model.items():`. Suggest a minor/major version bump.

## High severity
- **model:** `values()`/`items()`/`__iter__`/`current_state()` iterated the unordered `field_names` set while `keys()`/`to_dict()` used insertion order — keys and values were misaligned and non-deterministic across hash seeds (data corruption). Now all iterate `_key_order`.
- **output:** `__resolve_models` called `json.dumps()` on `Model` list elements → `TypeError` crash. Now serializes via `to_dict()`.
- **config:** user config was shallow-merged over defaults, dropping sibling keys in a nested override. Now deep-merges.
- **config:** blindly `setattr`'d every config key onto the instance, clobbering methods (`get`/`set`/`save`/…). Now skips reserved names.
- **output:** documented `table_options` (`exclude`/`headers`/`formatters`/`width`) were accepted but ignored. Now implemented.
- **updatechecker:** non-PEP440 version tags crashed the check. Now guarded with `InvalidVersion`.

## Medium severity
- **output:** rendering mutated the caller's models in place; now builds flattened rows without side effects.
- **output:** table headers taken only from the first model dropped columns unique to later rows; now uses the union.
- **output / logger / updatechecker:** attach handlers once and disable propagation to stop duplicate log output.
- **model:** `keys()` returned the internal list by reference; `__setitem__` didn't wrap nested dict/list in `Model`; `__copy__`/`__deepcopy__` dropped `_formatters`/`_remove_keys`. All fixed.
- **config:** env-var overrides now resolve to existing top-level keys before mapping `_`→`.` and are coerced to the existing value's type; `_load_default_config` handles `__file__ = None`; `validate_schema` no longer raises `NameError` when `jsonschema` is absent.
- **command:** verbose mode restored the shared logger's level after execution (no more DEBUG leak).
- **credentialmanager:** `keyring.get_password` guarded like set/delete.
- **cli:** honors `CommandError.exit_code`.

## Low severity
- **command:** applies the `log_level` constructor arg; treats `validate_args()` returning `False` as failure.
- **config:** `set()` warns before overwriting a non-dict intermediate; `save()` no longer persists the runtime `config_file_path` key.
- **logger:** normalizes string level names, selects format on `<= DEBUG`, and reapplies the formatter on re-call so `--verbose` reconfig works.
- **updatechecker:** tolerates non-dict JSON and malformed `last_check`; guards the temp-dir fallback; only advances `last_check` on a successful fetch (transient failures no longer suppress retries).

## Formatting
- Added `[tool.isort] profile = "black"` (the repo had no isort config, causing an import-wrap conflict with black) and ran both formatters across the codebase.

## Tests
Four existing tests that had codified buggy behavior were updated to assert the corrected contracts (update-status crash, verbose DEBUG leak), plus a new `test_model_iteration_yields_keys`.

## Deliberately not changed
Nothing outstanding — the one design-level finding (`__iter__` semantics) is included above per maintainer direction.