### PR TITLE
chore(ci): add Dependabot, update actions, expand Python matrix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Keep Python dependencies (uv / pyproject.toml + uv.lock) current
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:13"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/create_artifacts_and_publish.yaml
+++ b/.github/workflows/create_artifacts_and_publish.yaml
@@ -18,10 +18,10 @@ jobs:
       id-token: write # to mint OIDC token for attestation
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # required for setuptools-scm to resolve version from tags
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -31,11 +31,11 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Attest generated files
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v2
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/
       - name: Upload release distributions
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-dists
           path: dist/
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # required for setuptools-scm to resolve version from tags
       - name: Install uv
-        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Check lock file is up to date


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` covering the **github-actions** and **uv** ecosystems (weekly, grouped PRs). The `uv` ecosystem keeps both `pyproject.toml` and `uv.lock` in sync — the `pip` ecosystem does not regenerate the lockfile.
- Bump all pinned GitHub Actions to their latest release SHAs.
- Expand the pytest matrix to Python 3.13 and 3.14, covering the full `requires-python` range (`>=3.10,<4.0`).

## Action version bumps
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7.0.0 |
| `astral-sh/setup-uv` | v5 | v8.3.2 |
| `actions/setup-python` | v5 | v6.3.0 |
| `actions/attest-build-provenance` | v2 | v4.1.1 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/download-artifact` | v4 | v8.0.1 |
| `pypa/gh-action-pypi-publish` | v1.13.0 | v1.14.0 |

All remain pinned to commit SHAs with version comments. Verified upload-artifact v7 / download-artifact v8 stay compatible (default zipped uploads).

## Notes
- With the `uv` ecosystem, dependencies need version constraints in `pyproject.toml` for Dependabot to bump them in `uv.lock`; fully unconstrained deps may not get PRs.