### PR TITLE
fix: ship a py.typed marker (PEP 561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 include = ["cac_core*"]
 
+[tool.setuptools.package-data]
+# PEP 561: ship the marker so downstream projects' type checkers use cac-core's
+# inline type hints instead of treating it as an untyped dependency.
+"cac_core" = ["py.typed"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"


### PR DESCRIPTION
Closes #33

## Problem

cac-core ships inline type hints but no [`py.typed`](https://peps.python.org/pep-0561/) marker, so mypy treats it as an untyped dependency in downstream projects (e.g. cac-jira), emitting `import-untyped` / `import-not-found` for every `cac_core` import and drowning out real findings.

## Fix

- Add an empty `cac_core/py.typed`.
- Include it in the wheel via `[tool.setuptools.package-data]`.

## Verification

- Built the wheel and confirmed `cac_core/py.typed` is present in it.
- In an isolated venv with the built wheel installed, `mypy` now reads cac-core's hints (e.g. resolves `cac_core.cli.run` to `Callable[[Any, Any, Any], Any]` and flags a bad assignment) instead of skipping the package — the `import-untyped` / `import-not-found` errors are gone.
- cac-core's own suite is unaffected: 150 passed, 1 skipped, 94.96% coverage; ruff clean.

## Note

This changes the distributed package contents (advertising typing support per PEP 561), so it's worth including in the next release — a patch bump (2.0.1) is sufficient since it's additive and non-breaking.